### PR TITLE
fix: correct frontend test type mismatches and test configuration

### DIFF
--- a/pos-client/jest.config.js
+++ b/pos-client/jest.config.js
@@ -2,7 +2,8 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'jsdom',
   roots: ['<rootDir>/src'],
-  testMatch: ['**/__tests__/**/*.ts?(x)', '**/?(*.)+(spec|test).ts?(x)'],
+  testMatch: ['**/__tests__/**/*.test.ts?(x)', '**/?(*.)+(spec|test).ts?(x)'],
+  testPathIgnorePatterns: ['/node_modules/', 'setup\\.ts$'],
   transform: {
     '^.+\\.tsx?$': 'ts-jest',
   },

--- a/pos-client/src/__tests__/unit/components/SearchBar.test.tsx
+++ b/pos-client/src/__tests__/unit/components/SearchBar.test.tsx
@@ -47,7 +47,9 @@ describe('SearchBar Component', () => {
     renderSearchBar();
 
     const input = screen.getByPlaceholderText(/search products/i);
-    expect(input).toHaveAttribute('autoFocus');
+    // React autoFocus prop focuses the element but doesn't add the attribute to DOM
+    // Test that the element is focused instead
+    expect(document.activeElement).toBe(input);
   });
 
   it('should update input value when typing', () => {


### PR DESCRIPTION
## Summary
- Fixed all TypeScript type mismatches in frontend test files
- All 40 frontend tests now passing

## Changes

### auth.slice.test.ts
- Rewrote to match actual async thunk implementation (login/logout)
- Removed non-existent actions (loginSuccess, refreshTokenSuccess)
- Fixed User type to match API response
- Removed tokens from AuthState (stored in localStorage)

### cart.slice.test.ts
- Fixed property names: `tax` → `tax_amount`, `total` → `total_amount`
- Fixed CartItem structure: removed `id` field, uses `product_id`
- Fixed Product type: `price` → `base_price`, `cost` → `cost_price`
- Fixed `image_url`: `null` → `undefined`

### SearchBar.test.tsx
- Fixed autoFocus test to check element focus instead of DOM attribute

### jest.config.js
- Added `testPathIgnorePatterns` to exclude setup.ts from test matching

## Test Results
✅ All 40 frontend tests passing
- cart.slice.test.ts: 13 tests
- auth.slice.test.ts: 14 tests
- SearchBar.test.tsx: 13 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)