### PR TITLE
fix: exclude setup.ts from backend jest test matching

### DIFF
--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -2,7 +2,8 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   roots: ['<rootDir>/src'],
-  testMatch: ['**/__tests__/**/*.ts', '**/?(*.)+(spec|test).ts'],
+  testMatch: ['**/__tests__/**/*.test.ts', '**/?(*.)+(spec|test).ts'],
+  testPathIgnorePatterns: ['/node_modules/', 'setup\\.ts$'],
   transform: {
     '^.+\\.ts$': 'ts-jest',
   },


### PR DESCRIPTION
Quick fix to prevent setup.ts from being treated as a test file.

Resolves the "Your test suite must contain at least one test" error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)